### PR TITLE
[RFR] New read/write functions for 16 and 32 bit registers

### DIFF
--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -20,18 +20,13 @@ bool Battery::isCharging()
 
 float Battery::powerLevel()
 {
-	unsigned char high_byte, low_byte;
-
-	// get current voltage reading
-	// TODO: read both values at the same time, once we support that
-	Private::Wallaby::instance()->readRegister(REG_RW_BATT_H, high_byte);
-	Private::Wallaby::instance()->readRegister(REG_RW_BATT_L, low_byte);
-
 	// piece the 12-bit ADC result back together
-	unsigned short raw_batt_adc = (static_cast<unsigned short>(high_byte) << 8) | static_cast<unsigned short>(low_byte);
+	unsigned short raw_batt_adc = Private::Wallaby::instance()->readRegister16b(REG_RW_BATT_H);
 
 	// calculate voltage based on linear curve-fitting
 	float batt_voltage = -0.02070635f + 0.009071161f * static_cast<float>(raw_batt_adc);
+
+	// FIXME   ADC->capacity  or  voltage->capacity
 
 	return batt_voltage;
 }

--- a/src/digital_p.cpp
+++ b/src/digital_p.cpp
@@ -21,14 +21,7 @@ bool Digital::value(unsigned char port) const
 	// TODO which port is 0?
 	// TODO: boundary checking
 
-	unsigned char high_byte, low_byte;
-
-	// TODO: read both values at the same time, once we support that
-	// TODO: or just the byte we need
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_IN_H, high_byte);
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_IN_L, low_byte);
-
-	unsigned short dig_ins_val = (static_cast<unsigned short>(high_byte) << 8) | static_cast<unsigned short>(low_byte);
+	unsigned short dig_ins_val =  Private::Wallaby::instance()->readRegister16b(REG_RW_DIG_IN_H);
 
 	// TODO: what if this isn't a digital in
 	bool ret = dig_ins_val & (1 << port);
@@ -39,14 +32,8 @@ bool Digital::value(unsigned char port) const
 bool Digital::setValue(unsigned char port, bool value)
 {
 	// TODO boundary checks
-	unsigned char high_byte, low_byte;
 
-	// TODO: read both values at the same time, once we support that
-	// TODO: or just the byte we need
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_OUT_H, high_byte);
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_OUT_L, low_byte);
-
-	unsigned short out = (static_cast<unsigned short>(high_byte) << 8) | static_cast<unsigned short>(low_byte);
+	unsigned short out = Private::Wallaby::instance()->readRegister16b(REG_RW_DIG_OUT_H);
 
 	if (value)
 	{
@@ -57,13 +44,9 @@ bool Digital::setValue(unsigned char port, bool value)
 		out &= ~(1 << port);
 	}
 
-	high_byte = static_cast<unsigned char>((out & 0xFF00) >> 8);
-	low_byte = static_cast<unsigned char>(out & 0x00FF);
+	Private::Wallaby::instance()->writeRegister16b(REG_RW_DIG_OUT_H, out);
 
-	bool success = Private::Wallaby::instance()->writeRegister(REG_RW_DIG_OUT_H, high_byte)
-			& Private::Wallaby::instance()->writeRegister(REG_RW_DIG_OUT_L, low_byte);
-
-	return success;
+	return true; //TODO: return based on success
 }
 
 
@@ -73,14 +56,7 @@ const Digital::Direction Digital::direction(unsigned char port) const
 {
 	// TODO: bounds check, if not a good port return Digital::Unknown
 
-	unsigned char high_byte, low_byte;
-
-	// TODO: read both values at the same time, once we support that
-	// TODO: or just the byte we need
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_OE_H, high_byte);
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_OE_L, low_byte);
-
-	unsigned short outputs = (static_cast<unsigned short>(high_byte) << 8) | static_cast<unsigned short>(low_byte);
+	unsigned short outputs = Private::Wallaby::instance()->readRegister16b(REG_RW_DIG_OE_H);
 	Digital::Direction ret = outputs & (1 << port) ? Digital::Out : Digital::In;
 	return ret;
 }
@@ -92,13 +68,7 @@ bool Digital::setDirection(unsigned char port, const Digital::Direction & direct
 
 	if (direction == Digital::Unknown) return false;
 
-	unsigned char high_byte, low_byte;
-
-	// TODO: read both values at the same time, once we support that, or just the byte we need
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_OE_H, high_byte);
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_OE_L, low_byte);
-
-	unsigned short outputs = (static_cast<unsigned short>(high_byte) << 8) | static_cast<unsigned short>(low_byte);
+	unsigned short outputs = Private::Wallaby::instance()->readRegister16b(REG_RW_DIG_OE_H);
 
 	if (direction == Digital::Out)
 	{
@@ -109,27 +79,17 @@ bool Digital::setDirection(unsigned char port, const Digital::Direction & direct
 		outputs &= ~(1 << port);
 	}
 
-	high_byte = static_cast<unsigned char>((outputs & 0xFF00) >> 8);
-	low_byte = static_cast<unsigned char>(outputs & 0x00FF);
+	Private::Wallaby::instance()->writeRegister16b(REG_RW_DIG_OE_H, outputs);
 
-
-	bool success = Private::Wallaby::instance()->writeRegister(REG_RW_DIG_OE_H, high_byte)
-			& Private::Wallaby::instance()->writeRegister(REG_RW_DIG_OE_L, low_byte);
-
-	return success;
+	return true; // TODO: based on success;
 }
 
 
 bool Digital::pullup(unsigned char port) const
 {
 	// TODO: bounds checking (return false if out of range)
-	unsigned char high_byte, low_byte;
 
-	// TODO: read both values at the same time, once we support that, or just the byte we need
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_PE_H, high_byte);
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_PE_L, low_byte);
-
-	unsigned short pullups = (static_cast<unsigned short>(high_byte) << 8) | static_cast<unsigned short>(low_byte);
+	unsigned short pullups = Private::Wallaby::instance()->readRegister16b(REG_RW_DIG_PE_H);
 
 	bool ret = pullups & (1 << port);
 	return ret;
@@ -138,13 +98,7 @@ bool Digital::pullup(unsigned char port) const
 bool Digital::setPullup(unsigned char port, bool pullup)
 {
 	// TODO: bounds checking (return false if out of range)
-	unsigned char high_byte, low_byte;
-
-	// TODO: read both values at the same time, once we support that, or just the byte we need
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_PE_H, high_byte);
-	Private::Wallaby::instance()->readRegister(REG_RW_DIG_PE_L, low_byte);
-
-	unsigned short pullups = (static_cast<unsigned short>(high_byte) << 8) | static_cast<unsigned short>(low_byte);
+	unsigned short pullups = Private::Wallaby::instance()->readRegister16b(REG_RW_DIG_PE_H);
 
 	if (pullup)
 	{
@@ -155,14 +109,9 @@ bool Digital::setPullup(unsigned char port, bool pullup)
 		pullups &= ~(1 << port);
 	}
 
-	high_byte = static_cast<unsigned char>((pullups & 0xFF00) >> 8);
-	low_byte = static_cast<unsigned char>(pullups & 0x00FF);
+	Private::Wallaby::instance()->writeRegister16b(REG_RW_DIG_PE_H, pullups);
 
-
-	bool success = Private::Wallaby::instance()->writeRegister(REG_RW_DIG_PE_H, high_byte)
-			& Private::Wallaby::instance()->writeRegister(REG_RW_DIG_PE_L, low_byte);
-
-	return success;
+	return true; // TODO: based on success;
 }
 
 Digital * Digital::instance()

--- a/src/wallaby_p.cpp
+++ b/src/wallaby_p.cpp
@@ -86,24 +86,23 @@ bool Wallaby::transfer()
 	return true;
 }
 
-bool Wallaby::readRegister(unsigned short address, unsigned char & value)
+unsigned char Wallaby::readRegister8b(unsigned char address)
 {
-	if (address >= REG_ALL_COUNT) return false; // TODO: feedback
+	if (address >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
 
 	clear_buffers();
 
-	bool success = transfer();
+	//bool success = transfer();
+	//TODO: if (success == false) return false;
+	transfer();
 
-	if (success == false) return false;
-
-	value = read_buffer_[address];
-
-	return true;
+	unsigned char value = read_buffer_[address];
+	return value;
 }
 
-bool Wallaby::writeRegister(unsigned short address, unsigned char value)
+void Wallaby::writeRegister8b(unsigned char address, unsigned char value)
 {
-	if (address >= REG_ALL_COUNT) return false; // TODO: feedback
+	if (address >= REG_ALL_COUNT) return;// false; // TODO: feedback
 
 	clear_buffers();
 
@@ -112,9 +111,82 @@ bool Wallaby::writeRegister(unsigned short address, unsigned char value)
 	write_buffer_[3] = address; // at address 'address'
 	write_buffer_[4] = value; // with value 'value'
 
-	bool success = transfer();
+	//TODO: bool success = transfer();
+	//return success;
+	transfer();
+}
 
-	return success;
+unsigned short Wallaby::readRegister16b(unsigned char address)
+{
+	if (address >= REG_READABLE_COUNT || address+1 >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
+
+	clear_buffers();
+
+	//TODO: bool success = transfer();
+	//return success;
+	transfer();
+
+	unsigned short value = (static_cast<unsigned short>(read_buffer_[address]) << 8) | read_buffer_[address+1];
+	return value;
+}
+
+void Wallaby::writeRegister16b(unsigned char address, unsigned short value)
+{
+	if (address >= REG_ALL_COUNT || address+1 >= REG_ALL_COUNT) return;// false; // TODO: feedback
+
+	clear_buffers();
+
+	// TODO definitions for buffer inds
+	write_buffer_[2] = 2; // write 2 registers
+	write_buffer_[3] = address; // at address 'address'
+	write_buffer_[4] = static_cast<unsigned char>((value & 0xFF00) >> 8);
+	write_buffer_[5] = address + 1;
+	write_buffer_[6] = static_cast<unsigned char>(value & 0x00FF);
+
+	//TODO: bool success = transfer();
+	//return success;
+	transfer();
+}
+
+unsigned int Wallaby::readRegister32b(unsigned char address)
+{
+	if (address >= REG_READABLE_COUNT || address+3 >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
+
+	clear_buffers();
+
+	//TODO: bool success = transfer();
+	//return success;
+	transfer();
+
+	unsigned short value =
+			  (static_cast<unsigned int>(read_buffer_[address]) << 24)
+			| (static_cast<unsigned int>(read_buffer_[address+1]) << 16)
+			| (static_cast<unsigned int>(read_buffer_[address+2]) << 8)
+			| (static_cast<unsigned int>(read_buffer_[address+3]));
+
+	return value;
+}
+
+void Wallaby::writeRegister32b(unsigned char address, unsigned int value)
+{
+	if (address >= REG_ALL_COUNT || address+3 >= REG_ALL_COUNT) return;// false; // TODO: feedback
+
+	clear_buffers();
+
+	// TODO definitions for buffer inds
+	write_buffer_[2] = 2; // write 2 registers
+	write_buffer_[3] = address; // at address 'address'
+	write_buffer_[4] = static_cast<unsigned char>((value & 0xFF000000) >> 24);
+	write_buffer_[5] = address + 1;
+	write_buffer_[6] = static_cast<unsigned char>((value & 0x00FF0000) >> 16);
+	write_buffer_[7] = address + 2;
+	write_buffer_[8] = static_cast<unsigned char>((value & 0x0000FF00) >> 8);
+	write_buffer_[9] = address + 3;
+	write_buffer_[10] = static_cast<unsigned char>((value & 0x000000FF));
+
+	//TODO: bool success = transfer();
+	//return success;
+	transfer();
 }
 
 void Wallaby::clear_buffers()

--- a/src/wallaby_p.hpp
+++ b/src/wallaby_p.hpp
@@ -16,8 +16,15 @@ class Wallaby
 
 public:
 	static Wallaby * instance();
-	bool readRegister(unsigned short address, unsigned char & value);
-	bool writeRegister(unsigned short address, unsigned char value);
+
+	unsigned char readRegister8b(unsigned char address);
+	void writeRegister8b(unsigned char address, unsigned char value);
+
+	unsigned short readRegister16b(unsigned char address);
+	void writeRegister16b(unsigned char address, unsigned short value);
+
+	unsigned int readRegister32b(unsigned char address);
+	void writeRegister32b(unsigned char address, unsigned int value);
 
 	virtual ~Wallaby();
 


### PR DESCRIPTION
Adding and using new functions for reading and writing to registers that occupy  more than 8 bits with a single call.  This is faster than doing it one at a time and gets us closer to atomic updates.