### PR TITLE
[RFR] Fix enum mismatch for MAV

### DIFF
--- a/src/motors_p.hpp
+++ b/src/motors_p.hpp
@@ -19,8 +19,8 @@ public:
 	enum ControlMode
 	{
 		Inactive = 0,
-		Position,
 		Speed,
+		Position,
 		SpeedPosition
 	};
 


### PR DESCRIPTION
This probably got swapped on the firmware side... but I'm going to fix it here.