### PR TITLE
[RFR] Fixing digital in polarity for digital() call

### DIFF
--- a/src/digital_c.cpp
+++ b/src/digital_c.cpp
@@ -10,7 +10,7 @@
 
 int digital(int port)
 {
-	return !get_digital_value(port); // TODO: why is it !(...) ???
+	return get_digital_value(port);
 }
 
 void set_digital_value(int port, int value)


### PR DESCRIPTION
This changes fixes polarity so that ``digital(int port)`` matches ``get_digital_value(int port)``  where the pins are normally at ``0`` and a button press results in a ``1``