### PR TITLE
[RFR] Removing KeyCode hash that has been causing errors in botui

### DIFF
--- a/include/wallaby/graphics_key_code.h
+++ b/include/wallaby/graphics_key_code.h
@@ -136,19 +136,6 @@ extern "C" {
 
 #ifdef __cplusplus
 }
-
-#include <functional>
-namespace std
-{
-template<>
-struct hash<KeyCode>
-{
-  size_t operator()(const KeyCode &code) const
-  {
-    return code;
-  }
-};
-}
 #endif
 
 


### PR DESCRIPTION
It came from libaurora...  nothing seems to be using it.