### PR TITLE
[RFR] Fixing AccelY mapping in C++ interface

### DIFF
--- a/src/accel.cpp
+++ b/src/accel.cpp
@@ -36,7 +36,7 @@ short AccelX::value() const
 
 short AccelY::value() const
 {
-	return Private::accel_z();
+	return Private::accel_y();
 }
 
 short AccelZ::value() const


### PR DESCRIPTION
The C++ side was returning the z acceleration as y.