### PR TITLE
Two fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ file(GLOB SWIG_SOURCES ${BINDINGS}/*.i)
 
 if(build_python)
   find_package(SWIG REQUIRED)
-  find_package(PythonLibs REQUIRED)
+  find_package(PythonLibs 2.7 REQUIRED)
   message("${PYTHON_LIBRARY}")
   set(PYTHON_BINDING_SOURCES ${CMAKE_BINARY_DIR}/wallaby_wrap_py.cxx)
   set(PYTHON_BINDING_LIBRARIES ${PYTHON_LIBRARY})

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It was designed based on (and to be mostly compatible with) https://github.com/k
 Ubuntu Build Instructions
 ```` bash
 #Installing dependencies: 
-sudo apt-get install libzbar-dev libopencv-dev libjpeg-dev python-dev doxygen swig
+sudo apt-get install libzbar-dev libopencv-dev libjpeg-dev python-dev doxygen swig cmake
 
 # Create a build directory (inside libwallaby/) and change directory to it
 mkdir build


### PR DESCRIPTION
These commits make sure that CMake is installed and forces CMake to find Python 2 for the creation of bindings with Swig.