### PR TITLE
Fix double release (Resolves #107 Camera live crashes botui)

### DIFF
--- a/src/cap_v4l.cpp
+++ b/src/cap_v4l.cpp
@@ -271,7 +271,7 @@ make & enjoy!
 /* Defaults - If your board can do better, set it here.  Set for the most common type inputs. */
 #define DEFAULT_V4L_WIDTH  640
 #define DEFAULT_V4L_HEIGHT 480
-#define DEFAULT_V4L_FPS 30
+#define DEFAULT_V4L_FPS 15 
 
 #define MAX_CAMERAS 8
 
@@ -848,7 +848,7 @@ bool CvCaptureCAM_V4L_K::open(const char* _deviceName)
 // resetting the driver requires a longer timemout
 // reset takes between 310-350ms
     
-#define STIMEOUT_RESET_SEC    10
+#define STIMEOUT_RESET_SEC    3
 #define STIMEOUT_RESET_USEC   0
 
 static bool bufReturned;  // need to share this with tryIoctl to get the proper EAGAIN handling


### PR DESCRIPTION
The Camera::Device::close() released the capture object, which was
also done in the destructor for Camera::Device as well. Could not
remove this action from the close method becase the user progam
calles this function via a different path and multiple calls
could result in objects not being freed prpperly.

This patch also ensures that the VideoCapture_K can tbe constructed
with either a camera number or a path.