### PR TITLE
Set HIGH_RES as the Wombat camera default

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -286,7 +286,7 @@ Camera::Device::Device()
   m_fd(-1),
   m_cap(0),
   m_image(),
-  m_resolution(LOW_RES),
+  m_resolution(HIGH_RES /*LOW_RES*/),
   m_model(/*WHITE_2016*/ BLACK_2017)
 {
   Config *config = Config::load(Camera::ConfigPath::defaultConfigPath());
@@ -363,7 +363,7 @@ bool Camera::Device::open(const int number, Resolution resolution,
 	  }
 	  else
 	  {
-		  m_cap->set(cv::CAP_PROP_BUFFERSIZE, 4);  // minimize processing
+		  m_cap->set(cv::CAP_PROP_BUFFERSIZE, 10);  // minimize processing
 		  m_cap->set(cv::CAP_PROP_FPS, 15);        // slow down the input
 	  }
 	  m_connected = true;
@@ -827,7 +827,7 @@ int Camera::Device::readFrame() {
 	  if (!m_connected)
 	  {
 		printf("not connected\n");
-		open(0, LOW_RES, BLACK_2017); // TODO real numbers, we don't use these yet
+		open(0, HIGH_RES/*LOW_RES*/, BLACK_2017); // TODO real numbers, we don't use these yet
 		return -1;
 	  }
 

--- a/src/camera_c.cpp
+++ b/src/camera_c.cpp
@@ -28,11 +28,6 @@ int camera_open_black()
 
 int camera_open_at_res(enum Resolution res)
 {
-  if(res != LOW_RES) {
-    WARN("only LOW_RES is currently supported");
-    return 0;
-  }
-  
   return camera_open_device(0, res);
 }
 

--- a/src/camera_c.cpp
+++ b/src/camera_c.cpp
@@ -18,12 +18,12 @@ using namespace Private;
 
 int camera_open()
 {  
-  return camera_open_at_res(LOW_RES);
+  return camera_open_at_res(HIGH_RES/*LOW_RES*/);
 }
 
 int camera_open_black()
 {
-	return camera_open_device_model_at_res(0, BLACK_2017, LOW_RES);
+	return camera_open_device_model_at_res(0, BLACK_2017, HIGH_RES/*LOW_RES*/);
 }
 
 int camera_open_at_res(enum Resolution res)

--- a/src/cap_v4l.cpp
+++ b/src/cap_v4l.cpp
@@ -271,7 +271,7 @@ make & enjoy!
 /* Defaults - If your board can do better, set it here.  Set for the most common type inputs. */
 #define DEFAULT_V4L_WIDTH  640
 #define DEFAULT_V4L_HEIGHT 480
-#define DEFAULT_V4L_FPS 30
+#define DEFAULT_V4L_FPS 15 
 
 #define MAX_CAMERAS 8
 
@@ -848,7 +848,7 @@ bool CvCaptureCAM_V4L_K::open(const char* _deviceName)
 // resetting the driver requires a longer timemout
 // reset takes between 310-350ms
     
-#define STIMEOUT_RESET_SEC    10
+#define STIMEOUT_RESET_SEC    3
 #define STIMEOUT_RESET_USEC   0
 
 static bool bufReturned;  // need to share this with tryIoctl to get the proper EAGAIN handling

--- a/src/cap_v4l.cpp
+++ b/src/cap_v4l.cpp
@@ -271,7 +271,7 @@ make & enjoy!
 /* Defaults - If your board can do better, set it here.  Set for the most common type inputs. */
 #define DEFAULT_V4L_WIDTH  640
 #define DEFAULT_V4L_HEIGHT 480
-#define DEFAULT_V4L_FPS 15 
+#define DEFAULT_V4L_FPS  30
 
 #define MAX_CAMERAS 8
 

--- a/tests/camera_speed_test.c
+++ b/tests/camera_speed_test.c
@@ -10,35 +10,43 @@ int main()
 {
     int ret;
 
-    printf("Camera open\n");
-    camera_open_device_model_at_res(0, WHITE_2016, LOW_RES);
+    int resolution[3] = {LOW_RES, MED_RES, HIGH_RES };
 
-    printf("load config\n");
-    ret = camera_load_config("1");
-    if (ret == 1) printf("...success\n");
+    int res;
 
-    camera_update();
-    printf("Cam width x height:  %d x %d\n", get_camera_width(), get_camera_height());
-
-    printf("Num channels = %d\n", get_channel_count());
-
-
-    int i;
-    double start = seconds();
-    const int num_imgs = 60;
-    for (i = 0; i < num_imgs; ++i)
+    for (res = LOW_RES; res < 3; res++)
     {
-       camera_update();
-       int x = get_object_count(0) > 0 ? get_object_center_x(0,0) : -1;
-       int y = get_object_count(0) > 0 ? get_object_center_y(0,0) : -1;
-       printf("%f objs: %d  (%d,%d)\n", seconds(), get_object_count(0), x, y);
-       // printf("%f\n", seconds());
+
+    	printf("Camera open\n");
+    	camera_open_device_model_at_res(0, BLACK_2017, resolution[res]);
+
+    	printf("load config\n");
+    	ret = camera_load_config("1");
+    	if (ret == 1) printf("...success\n");
+
+    	camera_update();
+    	printf("Cam width x height:  %d x %d\n", get_camera_width(), get_camera_height());
+
+    	printf("Num channels = %d\n", get_channel_count());
+
+
+    	int i;
+    	double start = seconds();
+    	const int num_imgs = 60;
+    	for (i = 0; i < num_imgs; ++i)
+    	{
+       	   camera_update();
+           int x = get_object_count(0) > 0 ? get_object_center_x(0,0) : -1;
+           int y = get_object_count(0) > 0 ? get_object_center_y(0,0) : -1;
+           // printf("%f objs: %d  (%d,%d)\n", seconds(), get_object_count(0), x, y);
+           // printf("%f\n", seconds());
+    	} 
+    	double stop = seconds();
+
+    	printf("%f fps\n", ((double)num_imgs/(stop-start)));
+
+    	printf("Camera close\n");
+    	camera_close();
     }
-    double stop = seconds();
-
-    printf("%f fps\n", ((double)num_imgs/(stop-start)));
-
-    printf("Camera close\n");
-    camera_close();
     return 0;
 }


### PR DESCRIPTION
I have tested the Wombat and find that it can easily support 640x480, which is HIGH_RES.

FPS is set at 15, could go higher but this moderates the load on the CPU's and this rate is adequate for botball.

camera_speed_test has been modified to test all three resolutions.