### PR TITLE
[emscripten] Return control to JS before reading registers

### DIFF
--- a/src/wallaby_p.cpp
+++ b/src/wallaby_p.cpp
@@ -223,6 +223,7 @@ void Wallaby::writeRegister8b(unsigned char address, unsigned char value)
 unsigned short Wallaby::readRegister16b(unsigned char address, const unsigned char * alt_read_buffer)
 {
 	//emscripten_run_script("console.log('ReadRegister16b::start')");
+	emscripten_sleep(0);
 	if (address >= REG_READABLE_COUNT || address+1 >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
 
 	std::lock_guard<std::mutex> lock(transfer_mutex_);

--- a/src/wallaby_p.cpp
+++ b/src/wallaby_p.cpp
@@ -201,6 +201,8 @@ unsigned char Wallaby::readRegister8b(unsigned char address, const unsigned char
 {
 	//Testing the emscripten	
 	
+	emscripten_sleep(0);
+	
 	if (address >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
 
 	std::lock_guard<std::mutex> lock(transfer_mutex_);
@@ -224,6 +226,7 @@ unsigned short Wallaby::readRegister16b(unsigned char address, const unsigned ch
 {
 	//emscripten_run_script("console.log('ReadRegister16b::start')");
 	emscripten_sleep(0);
+
 	if (address >= REG_READABLE_COUNT || address+1 >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
 
 	std::lock_guard<std::mutex> lock(transfer_mutex_);
@@ -250,6 +253,8 @@ void Wallaby::writeRegister16b(unsigned char address, unsigned short value)
 
 unsigned int Wallaby::readRegister32b(unsigned char address, const unsigned char * alt_read_buffer)
 {
+	emscripten_sleep(0);
+	
 	if (address >= REG_READABLE_COUNT /* || address+3 >= REG_READABLE_COUNT*/) return 0;// false; // TODO: feedback
 
 	std::lock_guard<std::mutex> lock(transfer_mutex_);


### PR DESCRIPTION
Currently, running the user program blocks the web worker, preventing the worker from receiving any register updates from the simulator (like sensor updates). This PR adds `emscripten_sleep(0)` before any register read, briefly yielding control to the event loop and allowing it to process updates. 