### PR TITLE
Add emscripten support for simulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,8 +101,11 @@ if(with_vision_support)
   find_package(JPEG REQUIRED)
 endif()
 find_package (Threads)
-find_package( PythonInterp 2.7 REQUIRED )
-find_package( PythonLibs 2.7 REQUIRED )
+
+if(build_python)
+  find_package( PythonInterp 2.7 REQUIRED )
+  find_package( PythonLibs 2.7 REQUIRED )
+endif()
 
 include_directories(${CMAKE_INSTALL_PREFIX}/include)
 if(with_vision_support)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ project(libwallaby)
 # zoobee-wallaby controller			OFF					OFF	
 
 option(no_wallaby "Not a wallaby controller" OFF)
+option(with_vision_support "Controls camera support" ON)
 
 option(no_zoobee_wallaby "Not a zoobee wallaby controller" OFF)
 
@@ -20,6 +21,9 @@ if(no_wallaby)
   add_definitions(-DNOT_A_WALLABY)
 endif()
 
+if(with_vision_support)
+  add_definitions(-DWITH_VISION_SUPPORT)
+endif()
 
 if(USE_ARUCO)
 	add_definitions(-DARUCO)
@@ -92,20 +96,25 @@ elseif(WIN32)
   set(ZBAR_DIR "C:/Program Files (x86)/ZBar")
 endif()
 
-find_package(OpenCV REQUIRED )
-find_package(JPEG REQUIRED)
+if(with_vision_support)
+  find_package(OpenCV REQUIRED )
+  find_package(JPEG REQUIRED)
+endif()
 find_package (Threads)
 find_package( PythonInterp 2.7 REQUIRED )
 find_package( PythonLibs 2.7 REQUIRED )
 
 include_directories(${CMAKE_INSTALL_PREFIX}/include)
-include_directories(${OPENCV_INCLUDE})
-include_directories(${JPEG_INCLUDE_DIR})
-include_directories(${ZBAR_DIR}/include)
+if(with_vision_support)
+  include_directories(${OPENCV_INCLUDE})
+  include_directories(${JPEG_INCLUDE_DIR})
+  include_directories(${ZBAR_DIR}/include)
+
+  link_directories(${OPENCV_LIB})
+  link_directories(${ZBAR_DIR}/lib)
+endif()
 
 link_directories(${CMAKE_INSTALL_PREFIX}/lib)
-link_directories(${OPENCV_LIB})
-link_directories(${ZBAR_DIR}/lib)
 
 option(build_python "Build python bindings" ON)
 option(USE_ARUCO "Use Aruco Markers" OFF)
@@ -159,8 +168,10 @@ endif()
 add_library(wallaby SHARED ${SOURCES} ${PIXELTOASTER_SOURCES} ${OBJC_SOURCES})
 add_library(kipr SHARED ${SOURCES} ${PIXELTOASTER_SOURCES} ${OBJC_SOURCES})
 
-target_link_libraries(wallaby ${OpenCV_LIBS} ${JPEG_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} zbar opencv_core opencv_highgui opencv_imgproc)
-target_link_libraries(kipr ${OpenCV_LIBS} ${JPEG_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} zbar opencv_core opencv_highgui opencv_imgproc)
+if(with_vision_support)
+  target_link_libraries(wallaby ${OpenCV_LIBS} ${JPEG_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} zbar opencv_core opencv_highgui opencv_imgproc)
+  target_link_libraries(kipr ${OpenCV_LIBS} ${JPEG_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} zbar opencv_core opencv_highgui opencv_imgproc)
+endif()
 
 
 if(USE_ARUCO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 project(libwallaby)
 
@@ -54,17 +54,9 @@ file(GLOB PIXELTOASTER_SOURCES ${PIXELTOASTER}/*.cpp)
 
 
 # C++11
-# http://www.guyrutenberg.com/2014/01/05/enabling-c11-c0x-in-cmake/
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-	add_definitions(--std=c++11)
-elseif(COMPILER_SUPPORTS_CXX0X)
-	add_definitions(--std=c++0x)
-else()
-	message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
-endif()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 
 # REMOVE ME

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,17 @@ project(libwallaby)
 # zoobee-wallaby controller			OFF					OFF	
 
 option(no_wallaby "Not a wallaby controller" OFF)
+option(emscripten "Build for use with emscripten (for simulator)" OFF)
 option(with_vision_support "Controls camera support" ON)
 
 option(no_zoobee_wallaby "Not a zoobee wallaby controller" OFF)
 
 if(no_wallaby)
   add_definitions(-DNOT_A_WALLABY)
+endif()
+
+if(emscripten)
+  add_definitions(-DTARGET_EMSCRIPTEN)
 endif()
 
 if(with_vision_support)

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -5,6 +5,7 @@
  *      Author: Nafis Zaman
  */
 
+#ifdef WITH_VISION_SUPPORT
 
 #include "precomp.hpp"
 #include "wallaby/camera.hpp"
@@ -940,3 +941,4 @@ int Camera::Device::xioctl(int fh, int request, void *arg) {
 #endif
 }
 
+#endif

--- a/src/camera_c.cpp
+++ b/src/camera_c.cpp
@@ -5,6 +5,8 @@
  *      Author: Nafis Zaman
  */
 
+#ifdef WITH_VISION_SUPPORT
+
 #include "wallaby/camera.h"
 #include "wallaby/camera.hpp"
 #include "warn.hpp"
@@ -307,3 +309,5 @@ unsigned get_camera_element_size()
 {
   return DeviceSingleton::instance()->rawImage().elemSize();
 }
+
+#endif

--- a/src/camera_c_p.cpp
+++ b/src/camera_c_p.cpp
@@ -5,6 +5,8 @@
  *      Author: Nafis Zaman
  */
 
+#ifdef WITH_VISION_SUPPORT
+
 #include "camera_c_p.hpp"
 
 Camera::Device *Private::DeviceSingleton::s_device = 0;
@@ -14,3 +16,5 @@ Camera::Device *Private::DeviceSingleton::instance()
 	if(!s_device) s_device = new Camera::Device();
 	return s_device;
 }
+
+#endif

--- a/src/camera_c_p.hpp
+++ b/src/camera_c_p.hpp
@@ -5,6 +5,8 @@
  *      Author: Nafis Zaman
  */
 
+#ifdef WITH_VISION_SUPPORT
+
 #ifndef _CAMERA_C_P_HPP_
 #define _CAMERA_C_P_HPP_
 
@@ -21,5 +23,7 @@ namespace Private
     static ::Camera::Device *s_device;
   };
 }
+
+#endif
 
 #endif

--- a/src/cap_v4l.cpp
+++ b/src/cap_v4l.cpp
@@ -231,6 +231,8 @@ make & enjoy!
 //
 //M*/
 
+#ifdef WITH_VISION_SUPPORT
+
 #include "precomp.hpp"
 
 // added to have this compile with opencv v2
@@ -2166,5 +2168,7 @@ CvCapture* cvCreateCameraCapture_V4L_K( const char * deviceName )
     delete capture;
     return NULL;
 }
+
+#endif
 
 #endif

--- a/src/channel_p.cpp
+++ b/src/channel_p.cpp
@@ -5,6 +5,8 @@
  *      Author: Nafis Zaman
  */
 
+#ifdef WITH_VISION_SUPPORT
+
 #include "channel_p.hpp"
 #include "warn.hpp"
 #include <opencv2/core/core.hpp>
@@ -206,3 +208,5 @@ Camera::ObjectVector ArucoChannelImpl::findObjects(const Config &config) {
 
   return ret;
 }
+
+#endif

--- a/src/channel_p.hpp
+++ b/src/channel_p.hpp
@@ -5,6 +5,8 @@
  *      Author: Nafis Zaman
  */
 
+#ifdef WITH_VISION_SUPPORT
+
 #ifndef _CHANNEL_P_HPP_
 #define _CHANNEL_P_HPP_
 
@@ -53,5 +55,7 @@ namespace Private
     };
   }
 }
+
+#endif
 
 #endif

--- a/src/motor_p.cpp
+++ b/src/motor_p.cpp
@@ -44,8 +44,11 @@ int per_tick_large_to_small(int val)
 // TODO: this is a hack but the hardware timers are making it hard to easily swap motors 2,3 today
 unsigned int fix_port(unsigned int port)
 {
+  #ifndef NOT_A_WALLABY
   if (port == 2) return 3;
   if (port == 3) return 2;
+  #endif
+  
   return port;
 }
 

--- a/src/wallaby_p.cpp
+++ b/src/wallaby_p.cpp
@@ -213,6 +213,7 @@ unsigned char Wallaby::readRegister8b(unsigned char address, const unsigned char
 	if (alt_read_buffer == nullptr)
 	{
 		#ifdef TARGET_EMSCRIPTEN
+		emscripten_sleep(0);
 		read_buffer_[address] = readRegister(address);
 		#else
 		clearBuffers();
@@ -260,6 +261,7 @@ unsigned short Wallaby::readRegister16b(unsigned char address, const unsigned ch
 	if (alt_read_buffer == nullptr)
 	{
 		#ifdef TARGET_EMSCRIPTEN
+		emscripten_sleep(0);
 		read_buffer_[address] = readRegister(address);
 		read_buffer_[address+1] = readRegister(address+1);
 		#else
@@ -314,6 +316,7 @@ unsigned int Wallaby::readRegister32b(unsigned char address, const unsigned char
 	if (alt_read_buffer == nullptr)
 	{
 		#ifdef TARGET_EMSCRIPTEN
+		emscripten_sleep(0);
 		read_buffer_[address] = readRegister(address);
 		read_buffer_[address+1] = readRegister(address+1);
 		read_buffer_[address+2] = readRegister(address+2);

--- a/src/wallaby_p.cpp
+++ b/src/wallaby_p.cpp
@@ -41,6 +41,10 @@
 #include <iostream>
 #include <iomanip> // std::hex
 
+#ifdef TARGET_EMSCRIPTEN
+	#include <emscripten.h>
+#endif
+
 
 namespace Private
 {
@@ -182,6 +186,22 @@ bool Wallaby::transfer(unsigned char * alt_read_buffer)
 #endif
 }
 
+#ifdef TARGET_EMSCRIPTEN
+
+// emscripten function to write register values to JS registers variable
+EM_JS(void, updateRegister, (unsigned char address, unsigned char value), {
+	Module.context.registers[address] = value;
+	Module.context.onRegistersChange(address, value);
+
+});
+
+// emscripten function to read register values from JS registers variable
+EM_JS(unsigned char, readRegister, (unsigned char address), {
+	return Module.context.registers[address];
+});
+
+#endif
+
 unsigned char Wallaby::readRegister8b(unsigned char address, const unsigned char * alt_read_buffer)
 {
 	if (address >= REG_READABLE_COUNT) return 0;// false; // TODO: feedback
@@ -192,11 +212,15 @@ unsigned char Wallaby::readRegister8b(unsigned char address, const unsigned char
 
 	if (alt_read_buffer == nullptr)
 	{
+		#ifdef TARGET_EMSCRIPTEN
+		read_buffer_[address] = readRegister(address);
+		#else
 		clearBuffers();
 
 		//bool success = transfer();
 		//TODO: if (success == false) return false;
 		transfer();
+		#endif
 	}
 
 	unsigned char value = buffer[address];
@@ -209,6 +233,9 @@ void Wallaby::writeRegister8b(unsigned char address, unsigned char value)
 
 	std::lock_guard<std::mutex> lock(transfer_mutex_);
 
+	#ifdef TARGET_EMSCRIPTEN
+	updateRegister(address, value);
+	#else
 	clearBuffers();
 
 	// TODO definitions for buffer inds
@@ -219,6 +246,7 @@ void Wallaby::writeRegister8b(unsigned char address, unsigned char value)
 	//TODO: bool success = transfer();
 	//return success;
 	transfer();
+	#endif
 }
 
 unsigned short Wallaby::readRegister16b(unsigned char address, const unsigned char * alt_read_buffer)
@@ -231,11 +259,16 @@ unsigned short Wallaby::readRegister16b(unsigned char address, const unsigned ch
 
 	if (alt_read_buffer == nullptr)
 	{
+		#ifdef TARGET_EMSCRIPTEN
+		read_buffer_[address] = readRegister(address);
+		read_buffer_[address+1] = readRegister(address+1);
+		#else
 		clearBuffers();
 
 		//TODO: bool success = transfer();
 		//return success;
 		transfer();
+		#endif
 	}
 
 	unsigned short value = (static_cast<unsigned short>(buffer[address]) << 8) | buffer[address+1];
@@ -246,20 +279,28 @@ void Wallaby::writeRegister16b(unsigned char address, unsigned short value)
 {
 	if (address >= REG_ALL_COUNT || address+1 >= REG_ALL_COUNT) return;// false; // TODO: feedback
 
+	unsigned char value1 = static_cast<unsigned char>((value & 0xFF00) >> 8);
+	unsigned char value2 = static_cast<unsigned char>(value & 0x00FF);
+
 	std::lock_guard<std::mutex> lock(transfer_mutex_);
 
+	#ifdef TARGET_EMSCRIPTEN
+	updateRegister(address, value1);
+	updateRegister(address + 1, value2);
+	#else
 	clearBuffers();
 
 	// TODO definitions for buffer inds
 	write_buffer_[3] = 2; // write 2 registers
 	write_buffer_[4] = address; // at address 'address'
-	write_buffer_[5] = static_cast<unsigned char>((value & 0xFF00) >> 8);
+	write_buffer_[5] = value1;
 	write_buffer_[6] = address + 1;
-	write_buffer_[7] = static_cast<unsigned char>(value & 0x00FF);
+	write_buffer_[7] = value2;
 
 	//TODO: bool success = transfer();
 	//return success;
 	transfer();
+	#endif
 }
 
 unsigned int Wallaby::readRegister32b(unsigned char address, const unsigned char * alt_read_buffer)
@@ -272,11 +313,18 @@ unsigned int Wallaby::readRegister32b(unsigned char address, const unsigned char
 
 	if (alt_read_buffer == nullptr)
 	{
+		#ifdef TARGET_EMSCRIPTEN
+		read_buffer_[address] = readRegister(address);
+		read_buffer_[address+1] = readRegister(address+1);
+		read_buffer_[address+2] = readRegister(address+2);
+		read_buffer_[address+3] = readRegister(address+3);
+		#else
 		clearBuffers();
 
 		//TODO: bool success = transfer();
 		//return success;
 		transfer();
+		#endif		
 	}
 
 	unsigned int value =
@@ -292,24 +340,36 @@ void Wallaby::writeRegister32b(unsigned char address, unsigned int value)
 {
 	if (address >= REG_ALL_COUNT || address+3 >= REG_ALL_COUNT) return;// false; // TODO: feedback
 
+	unsigned char value1 = static_cast<unsigned char>((value & 0xFF000000) >> 24);
+	unsigned char value2 = static_cast<unsigned char>((value & 0x00FF0000) >> 16);
+	unsigned char value3 = static_cast<unsigned char>((value & 0x0000FF00) >> 8);
+	unsigned char value4 = static_cast<unsigned char>((value & 0x000000FF));
+
 	std::lock_guard<std::mutex> lock(transfer_mutex_);
 
+	#ifdef TARGET_EMSCRIPTEN
+	updateRegister(address, value1);
+	updateRegister(address + 1, value2);
+	updateRegister(address + 2, value3);
+	updateRegister(address + 3, value4);
+	#else
 	clearBuffers();
 
 	// TODO definitions for buffer inds
 	write_buffer_[3] = 4; // write 4 registers
 	write_buffer_[4] = address; // at address 'address'
-	write_buffer_[5] = static_cast<unsigned char>((value & 0xFF000000) >> 24);
+	write_buffer_[5] = value1;
 	write_buffer_[6] = address + 1;
-	write_buffer_[7] = static_cast<unsigned char>((value & 0x00FF0000) >> 16);
+	write_buffer_[7] = value2;
 	write_buffer_[8] = address + 2;
-	write_buffer_[9] = static_cast<unsigned char>((value & 0x0000FF00) >> 8);
+	write_buffer_[9] = value3;
 	write_buffer_[10] = address + 3;
-	write_buffer_[11] = static_cast<unsigned char>((value & 0x000000FF));
+	write_buffer_[11] = value4;
 
 	//TODO: bool success = transfer();
 	//return succes2;
 	transfer();
+	#endif
 }
 
 void Wallaby::clearBuffers()

--- a/tests/QRcode_test.c
+++ b/tests/QRcode_test.c
@@ -11,6 +11,7 @@
 #define SM 1
 int main() // assumes channel 2 is for QR codes
 {
+#ifdef WITH_VISION_SUPPORT
     const char *cp;
     const unsigned char *img;
     int i, j, n, cc, row, col;
@@ -47,5 +48,9 @@ int main() // assumes channel 2 is for QR codes
     }
     camera_close();
     printf("done\n");
+#else
+    printf("This platform does not support camera");
+#endif
+
     return 0;
 }

--- a/tests/aruco_test.c
+++ b/tests/aruco_test.c
@@ -30,6 +30,9 @@ int main(int argc, char const *argv[]) {
 // printf("Running the calibration\n");
 // bool calibrated = camera_calibrate();
 // printf(calibrated ? "true\n" : "false\n");
+#else
+  printf("This platform does not support ArUco");
 #endif
+
   return 0;
 }

--- a/tests/bounding_box_test.c
+++ b/tests/bounding_box_test.c
@@ -7,6 +7,7 @@
 // Revision: 9/3/2019 - cnw
 //    1. modified and modularized for Wombat KRC
 
+#include <stdio.h>
 #include <kipr/graphics.h>
 #include <kipr/graphics_characters.h>
 #include <kipr/camera.h>
@@ -25,6 +26,7 @@ void install_bboxes(int rgb[][3], rectangle bbcx[][5], int nx[]); // adds up to 
                                                 // to graphics window, color r,g,b
 int main()
   {
+#ifdef WITH_VISION_SUPPORT
     int n[3], b, c, cc, tf, row, col, rgb[3][3]={{255,0,0},{0,255,0},{0,0,255}}; // channel color for boxes
     rectangle bbcx [3][5]; // array of rectangles to hold up to 5 bounding boxes for up to 3 channels
     camera_open();         // open camera 
@@ -59,8 +61,14 @@ int main()
     // clean things up and exit
     camera_close();
     graphics_close();
+#else
+    printf("This platform does not support camera");
+#endif
+
     return 0;
 }
+
+#ifdef WITH_VISION_SUPPORT
 
 // display the camera CAMCOLSxCAMROWS pixel image in a graphics window
 void set_cam_image()
@@ -106,3 +114,5 @@ void install_bboxes(int rgb[][3], rectangle bbcx[][5], int nx[])
    }
    return;
 }
+
+#endif

--- a/tests/camera_speed_test.c
+++ b/tests/camera_speed_test.c
@@ -8,6 +8,7 @@
 
 int main()
 {
+#ifdef WITH_VISION_SUPPORT
     int ret;
 
     printf("Camera open\n");
@@ -40,5 +41,9 @@ int main()
 
     printf("Camera close\n");
     camera_close();
+#else
+    printf("This platform does not support camera");
+#endif
+
     return 0;
 }


### PR DESCRIPTION
Resolves #130 by adding emscripten support to `master`. Previously we were maintaining a separate `emscripten` branch for the simulator, which was quickly becoming unmanageable.

Main changes:
- Conditional logic for reading/writing registers when targeting emscripten (controlled by new CMake option: `emscripten`)
- Conditional compilation of camera-related files to allow building without vision support (controlled by new CMake option: `with_vision_support`). This includes "disabling" tests that depend on vision support. When building without vision support, those tests print out a warning
  - I went with conditional-compilation directives for this to stay consistent with other parts of libwallaby. But it kind of litters source files with `#ifdef`s. Might consider a separate issue/PR to instead have CMake handle these kinds of compile-time concerns
- In `motor_p.cpp`, wrap the port-swapping logic in a `NOT_A_WALLABY` conditional. We don't want ports to be swapped in the simulator (or any non-wallaby targets, I think)
- In `CMakeLists.txt`, set C++ standard using the newer [`CMAKE_CXX_STANDARD`](https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html) property. The old method was less flexible and caused issues by adding C++ flags during C compilation