### PR TITLE
[JS] Catch up on pending register values before writing registers

### DIFF
--- a/src/wallaby_p.cpp
+++ b/src/wallaby_p.cpp
@@ -244,6 +244,7 @@ void Wallaby::writeRegister8b(unsigned char address, unsigned char value)
 	std::lock_guard<std::mutex> lock(transfer_mutex_);
 
 	#ifdef TARGET_EMSCRIPTEN
+	emscripten_sleep(0);
 	unsigned char addresses[] = {address};
 	unsigned char values[] = {value};
 	updateRegisters(addresses, values, 1);
@@ -298,6 +299,7 @@ void Wallaby::writeRegister16b(unsigned char address, unsigned short value)
 	std::lock_guard<std::mutex> lock(transfer_mutex_);
 
 	#ifdef TARGET_EMSCRIPTEN
+	emscripten_sleep(0);
 	unsigned char addresses[] = {address, static_cast<unsigned char>(address + 1)};
 	unsigned char values[] = {value1, value2};
 	updateRegisters(addresses, values, 2);
@@ -363,6 +365,7 @@ void Wallaby::writeRegister32b(unsigned char address, unsigned int value)
 	std::lock_guard<std::mutex> lock(transfer_mutex_);
 
 	#ifdef TARGET_EMSCRIPTEN
+	emscripten_sleep(0);
 	unsigned char addresses[] = {address, static_cast<unsigned char>(address + 1), static_cast<unsigned char>(address + 2), static_cast<unsigned char>(address + 3)};
 	unsigned char values[] = {value1, value2, value3, value4};
 	updateRegisters(addresses, values, 4);


### PR DESCRIPTION
Fixes kipr/Simulator#117 by yielding to the event loop before writing register values, allowing the worker to catch up on pending "set register" requests.

This fixes a bug where libwallaby would write to a register, but the value wouldn't be sent to the simulator because libwallaby thought the value was unchanged. Really the value *was* changed, but libwallaby didn't know about it yet.