### PR TITLE
Fix `mtp` race condition

### DIFF
--- a/src/motors_c.cpp
+++ b/src/motors_c.cpp
@@ -52,9 +52,9 @@ int move_to_position(int motor, int speed, int goal_pos)
 	const short velocity = std::abs(speed) * sign;
 
 	// TODO: combine into one call
-	Private::set_motor_mode(motor, Private::Motor::SpeedPosition);
 	Private::set_motor_goal_position(motor, goal_pos);
 	Private::set_motor_goal_velocity(motor, velocity);
+	Private::set_motor_mode(motor, Private::Motor::SpeedPosition);
 
 	return 0;
 }


### PR DESCRIPTION
Fixes #150 by reordering the register writes in `mtp` to avoid a bad race condition. See my comment in #150 for more details on the issue and other possible solutions.

I tested this using the code in #150, as well as other edge cases I could think of by combining `motor`/`mtp`/`mrp`/`bmd` in different ways. But it'd be good for someone else to test too.

Or if someone implements a different solution, I'm happy to abandon this PR.