### PR TITLE
have the correct architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ else()
   target_link_libraries(kipr PRIVATE "-Wl,-Bsymbolic" ${STATIC_KIPR_MODULES})
 endif()
 target_link_libraries(kipr INTERFACE ${STATIC_KIPR_MODULES})
+target_link_options(kipr PRIVATE -static-libgcc -static-libstdc++)  # since wombat is still on jessie, needs the latest g++, gcc
 
 if (TARGET kipr_python)
   target_link_libraries(kipr PRIVATE kipr_python)

--- a/toolchain/arm-linux-gnueabihf.cmake
+++ b/toolchain/arm-linux-gnueabihf.cmake
@@ -1,14 +1,14 @@
 # set(CMAKE_SYSROOT ${AARCH64_LINUX_GNU_SYSROOT})
-set(ARCH aarch64)
+set(ARCH armv7l)
 
 set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_SYSTEM_PROCESSOR armv7l)
 
-set(triple aarch64-linux-gnu)
+set(triple arm-linux-gnueabihf)
 
 set_property(GLOBAL PROPERTY host aarch64-linux)
 set_property(GLOBAL PROPERTY triple ${triple})
-set_property(GLOBAL PROPERTY arch aarch64)
+set_property(GLOBAL PROPERTY arch armv7l)
 set_property(GLOBAL PROPERTY target_os linux)
 set_property(GLOBAL PROPERTY cross_prefix ${triple}-)
 


### PR DESCRIPTION
There's still problems w/ cross compiling (since jessie is older than buster and lacks the current libs)

Library problems (checkmark = fixed)
-[x] w/o static linking libstdc++, there's a problem with unfound libstdc++ version GLIBCXX_3.4.26
-[] can't find the right library, but there's problem with version `GLIBC_2.29' not found 
