### PR TITLE
Adding stdexcept because std::out_of_range is used in the .cpp

### DIFF
--- a/module/motor/protected/kipr/motor/command.hpp
+++ b/module/motor/protected/kipr/motor/command.hpp
@@ -9,6 +9,7 @@
 #include <array>
 
 #include <cstdint>
+#include <stdexcept>
 
 namespace kipr
 {

--- a/module/motor/protected/kipr/motor/command.hpp
+++ b/module/motor/protected/kipr/motor/command.hpp
@@ -9,7 +9,6 @@
 #include <array>
 
 #include <cstdint>
-#include <stdexcept>
 
 namespace kipr
 {

--- a/module/motor/src/command.cpp
+++ b/module/motor/src/command.cpp
@@ -1,4 +1,5 @@
 #include "kipr/motor/command.hpp"
+#include <stdexcept>
 
 using namespace kipr;
 using namespace kipr::motor;


### PR DESCRIPTION
Adding this allows the project to build on a Wombat.