### PR TITLE
Fixing printf modifiers

### DIFF
--- a/module/camera/src/camera.cpp
+++ b/module/camera/src/camera.cpp
@@ -754,7 +754,7 @@ int Device::readFrame()
     buf.memory = V4L2_MEMORY_MMAP;
     if (xioctl(m_fd, VIDIOC_DQBUF, &buf) == -1)
     {
-      printf("DQBUF Error: $d\n", errno);
+      printf("DQBUF Error: %d\n", errno);
       switch (errno)
       {
       case EAGAIN:

--- a/module/tello/src/tello.cpp
+++ b/module/tello/src/tello.cpp
@@ -41,7 +41,7 @@ int wpa_cmd(char const *cmd, char *buf)
 
   printf("wpa_cmd: %s\n", cmd);
   cmd_len = (size_t)strlen(cmd);
-  printf("cmd_len %d\n", cmd_len);
+  printf("cmd_len %zu\n", cmd_len);
   len = BUFSIZE;
   result = wpa_ctrl_request(ctrl_conn,
                             cmd,
@@ -49,7 +49,7 @@ int wpa_cmd(char const *cmd, char *buf)
                             buf,
                             &len,
                             wpa_cli_msg_cb);
-  printf("len %d\n", len);
+  printf("len %zu\n", len);
   buf[len] = '\0';
   printf("%s\n", buf);
 


### PR DESCRIPTION
This produces warning(s)

The $ is a valid "operator" for printf, so I dug around to make sure this wasn't intentional, maybe there is some C++ trickery I hadn't seen before. I couldn't find any reference that uses $ this way.

I also noticed after the fact that in the same file the identical expression exists but with % as I would have expected, so I'm certain it's a typo.