### PR TITLE
Fixing constructor priority warning

### DIFF
--- a/module/servo/src/init.cpp
+++ b/module/servo/src/init.cpp
@@ -3,7 +3,7 @@
 
 namespace
 {
-  __attribute__((constructor(2)))
+  __attribute__((constructor(102)))
   void register_servo_cleanup()
   {
     kipr::core::cleanup_add(disable_servos);


### PR DESCRIPTION
If the original was intentional, feel free to delete this PR.

This section throws the following warning:
```
/home/zachary/libwallaby/module/servo/src/init.cpp:7:31: warning: constructor priorities from 0 to 100 are reserved for the implementation [-Wprio-ctor-dtor]
    7 |   void register_servo_cleanup()
      |                               ^
```

This comes from this definition:
```
#include "kipr/servo/servo.h"
#include "kipr/core/cleanup.hpp"

namespace
{
  __attribute__((constructor(2)))
  void register_servo_cleanup()
  {
    kipr::core::cleanup_add(disable_servos);
  }
}
```

According to C++ documentation, 0-100 is reserved for internal use.
However, in the commit that made this change Braden says it is to get around WASM bugs, so it may have been intentional.
I tried to find the WASM/emscripten error that would have prompted the change, but I couldn't find anything.
I did find documentation saying that emscripten uses a priority of 50, so it's possible 2 was chosen to beat that value.

I would test this to see what bugs appear, but I don't know what build configuration is being used for WASM.