### PR TITLE
Warning

### DIFF
--- a/module/camera/src/cap_v4l.cpp
+++ b/module/camera/src/cap_v4l.cpp
@@ -1066,7 +1066,7 @@ bool CvCaptureCAM_V4L_K::tryIoctl(unsigned long ioctlCode, void *parameter) //co
                 	DqbufTimeoutuSec  = STIMEOUT_RESET_USEC;
                 //	v4l2_reset();
 		//}
-                printf("camera driver reset - time: %d\n", systime() - StartTime);
+                printf("camera driver reset - time: %lu\n", systime() - StartTime);
             }
             
             return false;

--- a/module/graphics/src/graphics.cpp
+++ b/module/graphics/src/graphics.cpp
@@ -134,7 +134,7 @@ inline Pixel fromTrueColor(Encoding enc, const int _0, const int _1, const int _
 {
 	switch(enc) {
 		case RGB: return Pixel(_0 / 255.0, _1 / 255.0, _2 / 255.0);
-		case BGR: return Pixel(_2 / 255.0, _1 / 255.0, _0 / 255.0);
+		default: return Pixel(_2 / 255.0, _1 / 255.0, _0 / 255.0);
 	}
 }
 


### PR DESCRIPTION
**Preventing non-return on non-void function:**
```
/home/zachary/libwallaby/module/graphics/src/graphics.cpp: In function ‘PixelToaster::Pixel fromTrueColor(Encoding, int, int, int)’:
/home/zachary/libwallaby/module/graphics/src/graphics.cpp:139:1: warning: control reaches end of non-void function [-Wreturn-type]
  139 | }
      | ^
```
The compiler is unaware that there are only two valid inputs for the definition Encoding. 
Changing the bottom case to default shouldn't change anything functionally since BGR and RGB are the only valid encodings.

**Changing printf %d to %lu for long unsigned int:**
This throws a warning because %d is not the correct printf syntax for long unsigned ints.
%lu matches the C++ docs and removes the warning.