### PR TITLE
[refactor] Implement assignment operator in Image

### DIFF
--- a/module/camera/public/kipr/camera/image.hpp
+++ b/module/camera/public/kipr/camera/image.hpp
@@ -1,6 +1,8 @@
 #ifndef _KIPR_CAMERA_IMAGE_HPP_
 #define _KIPR_CAMERA_IMAGE_HPP_
 
+#include <algorithm>
+
 namespace kipr
 {
   namespace camera
@@ -29,6 +31,8 @@ namespace kipr
       Image(const Image &);
       Image(Image &&);
 
+      Image &operator=(Image);
+
       ~Image();
 
       bool isEmpty() const;
@@ -40,6 +44,17 @@ namespace kipr
       unsigned getHeight() const;
       unsigned getStride() const;
       bool isOwned() const;
+
+      friend void swap(Image &first, Image &second)
+      {
+        using std::swap;
+        swap(first.type_, second.type_);
+        swap(first.data_, second.data_);
+        swap(first.owned_, second.owned_);
+        swap(first.width_, second.width_);
+        swap(first.height_, second.height_);
+        swap(first.stride_, second.stride_);
+      }
 
     private:
       Type type_;

--- a/module/camera/src/image.cpp
+++ b/module/camera/src/image.cpp
@@ -53,6 +53,12 @@ Image::Image(Image &&rhs)
   rhs.owned_ = false;
 }
 
+Image &Image::operator=(Image other)
+{
+  swap(*this, other);
+  return *this;
+}
+
 Image::~Image()
 {
   if (owned_) delete[] data_;


### PR DESCRIPTION
(to be merged into `refactor` branch, not `master`)

Implement assignment operator in `Image`. Since `Image` has a move constructor, the default assignment operator gets deleted. So we have to implement our own assignment operator to support usage like:

```
m_image = kipr::camera::Image();
```