### PR TITLE
Link Patch

### DIFF
--- a/binding/python/CMakeLists.txt
+++ b/binding/python/CMakeLists.txt
@@ -39,8 +39,7 @@ if(with_python_binding)
   
   # link library to kipr objects
   target_link_libraries(kipr_python PRIVATE ${KIPR_MODULES})
-  target_link_libraries(kipr_python PRIVATE ${KIPR_MODULE_OBJECTS})
-  set_target_properties(kipr_python PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_link_libraries(kipr_python PRIVATE "-Wl,-Bsymbolic" ${KIPR_MODULE_OBJECTS})
 
   # according to swig specifications, the output library must be
   # named _kipr.so


### PR DESCRIPTION
# Changes
* use correct link flag to prevent error
* remove redundant line since `kipr_python` is already a shared library, meaning it already is PIC

## Error description
When building libwallaby with python bindings and camera module enabled, the following error occurs:
![image](https://github.com/kipr/libwallaby/assets/60240707/47a5fb61-67c3-472e-b9a5-dc3047f537ca)
