### PR TITLE
lock mutexes in reads/writes

### DIFF
--- a/module/core/src/device/wombat/wombat_device.cpp
+++ b/module/core/src/device/wombat/wombat_device.cpp
@@ -56,6 +56,7 @@ public:
 
   virtual std::uint8_t r8(const std::uint8_t address) override
   {
+    std::lock_guard<std::mutex> transfer_lock(mut_);
     clear_buffers();
     transfer();
 
@@ -64,6 +65,7 @@ public:
 
   virtual std::uint16_t r16(const std::uint8_t address) override
   {
+    std::lock_guard<std::mutex> transfer_lock(mut_);
     clear_buffers();
     transfer();
 
@@ -74,6 +76,7 @@ public:
 
   virtual std::uint32_t r32(const std::uint8_t address) override
   {
+    std::lock_guard<std::mutex> transfer_lock(mut_);
     clear_buffers();
     transfer();
 
@@ -86,6 +89,7 @@ public:
 
   virtual void w8(const std::uint8_t address, const std::uint8_t value) override
   {
+    std::lock_guard<std::mutex> transfer_lock(mut_);
     clear_buffers();
     write_buf[3] = 1,
     write_buf[4] = address,
@@ -96,6 +100,7 @@ public:
 
   virtual void w16(const std::uint8_t address, const std::uint16_t value) override
   {
+    std::lock_guard<std::mutex> transfer_lock(mut_);
     clear_buffers();
     write_buf[3] = 2,
     write_buf[4] = address,
@@ -108,6 +113,7 @@ public:
 
   virtual void w32(const std::uint8_t address, const std::uint32_t value) override
   {
+    std::lock_guard<std::mutex> transfer_lock(mut_);
     clear_buffers();
     write_buf[3] = 4;
     write_buf[4] = address,
@@ -131,8 +137,6 @@ private:
 
   bool transfer()
   {
-    std::lock_guard<std::mutex> lock(mut_);
-
     ++count;
     write_buf[0] = 'J';
     write_buf[1] = WALLABY_SPI_VERSION;


### PR DESCRIPTION
* lock mutexes in the `r8`, `r16`, ... as well as the `w8`, `w16`, ... functions. This prevents any DMA-desynchronized due to unsafe thread accessing

Problem:
* "DMA desynchronized" -> program exited with code null
Why it happens:
* Previously, the mutex was released after the transfer function, meaning that another thread could start a transfer while the initial one was still trying to access the memory. By locking the mutex in the read and write functions themselves, my tests didn't get any more segmentation faults / DMA desynchronized