### PR TITLE
Fixed missing semicolon from previous pull request

### DIFF
--- a/module/botball/src/botball_c.cpp
+++ b/module/botball/src/botball_c.cpp
@@ -140,7 +140,7 @@ void wait_for_light(int port)
                 printf("Threshold Value: %d \n \n", threshold);
                 printf("Current Value: %d  <----  \n", analog(port));
 
-                unsigned long startTime = systime()
+                unsigned long startTime = systime();
                 while ((systime() - startTime) < 2000) {
                     if (analog(port) > threshold) {
                         break;


### PR DESCRIPTION
Apologies for the inconvenience, but after updating and compiling libwallay, I realized that I forgot to include the commit in the pull request where I corrected a missing semicolon. The issue occurred in the botball module within the wait_for_light function, which I recently modified and merged successfully. Unfortunately, this merge introduced an error that prevents the entire module from compiling - specifically, the semicolon commit I forgot to push onto github and therefore wasn't included in my pull request.