### PR TITLE
Threads created and managed by libwallaby will now allow variables to get passed into it

### DIFF
--- a/module/core/src/device/wombat/wombat_device.cpp
+++ b/module/core/src/device/wombat/wombat_device.cpp
@@ -15,172 +15,159 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "mutex"
 
 #define SPI_FILE_SYSTEM ("/dev/spidev0.0")
 
-namespace
-{
-  const std::string NAME = "wombat";
-  kipr::log::Log logger("core/wombat");
+namespace {
+    const std::string NAME = "wombat";
+    kipr::log::Log logger("core/wombat");
 }
 
-class WombatDevice : public kipr::core::Device
-{
+class WombatDevice : public kipr::core::Device {
 public:
-  WombatDevice()
-      : spi_fd_(-1),
-        count(0),
-        read_buf(new std::uint8_t[REG_READABLE_COUNT]),
-        write_buf(new std::uint8_t[REG_READABLE_COUNT])
-  {
-    spi_fd_ = open(SPI_FILE_SYSTEM, O_RDWR);
-    if (spi_fd_ <= 0)
-    {
-      logger.fatal() << "Not found: " << SPI_FILE_SYSTEM;
+    WombatDevice()
+            : spi_fd_(-1),
+              count(0),
+              read_buf(new std::uint8_t[REG_READABLE_COUNT]),
+              write_buf(new std::uint8_t[REG_READABLE_COUNT]) {
+        spi_fd_ = open(SPI_FILE_SYSTEM, O_RDWR);
+        if (spi_fd_ <= 0) {
+            logger.fatal() << "Not found: " << SPI_FILE_SYSTEM;
+        }
+        clear_buffers();
     }
-    clear_buffers();
-  }
 
-  virtual ~WombatDevice()
-  {
-    std::cout << "~Wombat()" << std::endl;
-    close(spi_fd_);
-    delete[] read_buf;
-    delete[] write_buf;
-  }
+    virtual ~WombatDevice() {
+        std::cout << "~Wombat()" << std::endl;
+        close(spi_fd_);
+        delete[] read_buf;
+        delete[] write_buf;
+    }
 
-  virtual const std::string &getName() const override
-  {
-    return NAME;
-  }
+    virtual const std::string &getName() const override {
+        return NAME;
+    }
 
-  virtual std::uint8_t r8(const std::uint8_t address) override
-  {
-    clear_buffers();
-    transfer();
+    virtual std::uint8_t r8(const std::uint8_t address) override {
+        std::lock_guard<std::mutex> lock(mut_);
+        clear_buffers();
+        transfer();
 
-    return read_buf[address];
-  }
+        return read_buf[address];
+    }
 
-  virtual std::uint16_t r16(const std::uint8_t address) override
-  {
-    clear_buffers();
-    transfer();
+    virtual std::uint16_t r16(const std::uint8_t address) override {
+        std::lock_guard<std::mutex> lock(mut_);
+        clear_buffers();
+        transfer();
 
-    return (
-        read_buf[address] << 8 |
-        read_buf[address + 1] << 0);
-  }
+        return (
+                read_buf[address] << 8 |
+                read_buf[address + 1] << 0);
+    }
 
-  virtual std::uint32_t r32(const std::uint8_t address) override
-  {
-    clear_buffers();
-    transfer();
+    virtual std::uint32_t r32(const std::uint8_t address) override {
+        std::lock_guard<std::mutex> lock(mut_);
+        clear_buffers();
+        transfer();
 
-    return (
-        read_buf[address] << 24 |
-        read_buf[address + 1] << 16 |
-        read_buf[address + 2] << 8 |
-        read_buf[address + 3] << 0);
-  }
+        return (
+                read_buf[address] << 24 |
+                read_buf[address + 1] << 16 |
+                read_buf[address + 2] << 8 |
+                read_buf[address + 3] << 0);
+    }
 
-  virtual void w8(const std::uint8_t address, const std::uint8_t value) override
-  {
-    clear_buffers();
-    write_buf[3] = 1,
-    write_buf[4] = address,
-    write_buf[5] = value;
+    virtual void w8(const std::uint8_t address, const std::uint8_t value) override {
+        std::lock_guard<std::mutex> lock(mut_);
+        clear_buffers();
+        write_buf[3] = 1,
+        write_buf[4] = address,
+        write_buf[5] = value;
 
-    transfer();
-  }
+        transfer();
+    }
 
-  virtual void w16(const std::uint8_t address, const std::uint16_t value) override
-  {
-    clear_buffers();
-    write_buf[3] = 2,
-    write_buf[4] = address,
-    write_buf[5] = (value & 0xFF00) >> 8,
-    write_buf[6] = address + 1,
-    write_buf[7] = (value & 0x00FF) >> 0,
+    virtual void w16(const std::uint8_t address, const std::uint16_t value) override {
+        std::lock_guard<std::mutex> lock(mut_);
+        clear_buffers();
+        write_buf[3] = 2,
+        write_buf[4] = address,
+        write_buf[5] = (value & 0xFF00) >> 8,
+        write_buf[6] = address + 1,
+        write_buf[7] = (value & 0x00FF) >> 0,
 
-    transfer();
-  }
+                transfer();
+    }
 
-  virtual void w32(const std::uint8_t address, const std::uint32_t value) override
-  {
-    clear_buffers();
-    write_buf[3] = 4;
-    write_buf[4] = address,
-    write_buf[5] = (value & 0xFF000000) >> 24,
-    write_buf[6] = address + 1,
-    write_buf[7] = (value & 0x00FF0000) >> 16,
-    write_buf[8] = address + 2,
-    write_buf[9] = (value & 0x0000FF00) >> 8,
-    write_buf[10] = address + 3,
-    write_buf[11] = (value & 0x000000FF) >> 0,
+    virtual void w32(const std::uint8_t address, const std::uint32_t value) override {
+        std::lock_guard<std::mutex> lock(mut_);
+        clear_buffers();
+        write_buf[3] = 4;
+        write_buf[4] = address,
+        write_buf[5] = (value & 0xFF000000) >> 24,
+        write_buf[6] = address + 1,
+        write_buf[7] = (value & 0x00FF0000) >> 16,
+        write_buf[8] = address + 2,
+        write_buf[9] = (value & 0x0000FF00) >> 8,
+        write_buf[10] = address + 3,
+        write_buf[11] = (value & 0x000000FF) >> 0,
 
-    transfer();
-  }
+                transfer();
+    }
 
 private:
-  void clear_buffers()
-  {
-    memset(write_buf, 0, REG_READABLE_COUNT);
-    memset(read_buf, 0, REG_READABLE_COUNT);
-  }
-
-  bool transfer()
-  {
-    std::lock_guard<std::mutex> lock(mut_);
-
-    ++count;
-    write_buf[0] = 'J';
-    write_buf[1] = WALLABY_SPI_VERSION;
-    write_buf[2] = count;
-    write_buf[REG_READABLE_COUNT - 1] = 'S';
-
-    struct spi_ioc_transfer xfer[1];
-    memset(xfer, 0, sizeof xfer);
-
-    xfer[0].tx_buf = (unsigned long)write_buf;
-    xfer[0].rx_buf = (unsigned long)read_buf;
-    xfer[0].len = REG_READABLE_COUNT;
-    xfer[0].speed_hz = 16000000;
-
-    const int status = ioctl(spi_fd_, SPI_IOC_MESSAGE(1), xfer);
-
-    usleep(50); // FIXME: this  makes sure we don't outrun the co-processor until interrupts are in place for DMA
-
-    if (status < 0)
-    {
-      logger.error() << "SPI_IOC_MESSAGE: " << strerror(errno);
-      return false;
+    void clear_buffers() {
+        memset(write_buf, 0, REG_READABLE_COUNT);
+        memset(read_buf, 0, REG_READABLE_COUNT);
     }
 
-    if (read_buf[0] != static_cast<unsigned char>('J'))
-    {
-      logger.error() << "DMA de-synchronized";
-      return false;
+    bool transfer() {
+        ++count;
+        write_buf[0] = 'J';
+        write_buf[1] = WALLABY_SPI_VERSION;
+        write_buf[2] = count;
+        write_buf[REG_READABLE_COUNT - 1] = 'S';
+
+        struct spi_ioc_transfer xfer[1];
+        memset(xfer, 0, sizeof xfer);
+
+        xfer[0].tx_buf = (unsigned long) write_buf;
+        xfer[0].rx_buf = (unsigned long) read_buf;
+        xfer[0].len = REG_READABLE_COUNT;
+        xfer[0].speed_hz = 16000000;
+
+        const int status = ioctl(spi_fd_, SPI_IOC_MESSAGE(1), xfer);
+
+        usleep(50); // FIXME: this  makes sure we don't outrun the co-processor until interrupts are in place for DMA
+
+        if (status < 0) {
+            logger.error() << "SPI_IOC_MESSAGE: " << strerror(errno);
+            return false;
+        }
+
+        if (read_buf[0] != static_cast<unsigned char>('J')) {
+            logger.error() << "DMA de-synchronized";
+            return false;
+        }
+
+        return true;
     }
 
-    return true;
-  }
-
-  int spi_fd_;
-  std::mutex mut_;
-  std::uint8_t count;
-  std::uint8_t *write_buf;
-  std::uint8_t *read_buf;
+    int spi_fd_;
+    std::mutex mut_;
+    std::uint8_t count;
+    std::uint8_t *write_buf;
+    std::uint8_t *read_buf;
 };
 
-struct WombatDeviceDescriptor
-{
-  typedef WombatDevice DeviceType;
+struct WombatDeviceDescriptor {
+    typedef WombatDevice DeviceType;
 
-  static bool isPresent()
-  {
-    return access(SPI_FILE_SYSTEM, F_OK) == 0;
-  }
+    static bool isPresent() {
+        return access(SPI_FILE_SYSTEM, F_OK) == 0;
+    }
 };
 
 KIPR_CORE_PLATFORM_DEVICE_REGISTER(WombatDeviceDescriptor);

--- a/module/thread/public/kipr/thread/thread.h
+++ b/module/thread/public/kipr/thread/thread.h
@@ -9,7 +9,8 @@
 #ifndef _KIPR_THREAD_THREAD_H_
 #define _KIPR_THREAD_THREAD_H_
 
-#include "kipr/export/export.h"  
+#include "kipr/export/export.h"
+#include <functional>
 
 #ifdef __cplusplus
 extern "C" {

--- a/module/thread/public/kipr/thread/thread.h
+++ b/module/thread/public/kipr/thread/thread.h
@@ -47,7 +47,7 @@ typedef struct
  * be threaded
  * \ingroup thread
  */
-typedef void (*thread_function)();
+typedef std::function<void()> thread_function;
 
 /**
  * Create a mutex.


### PR DESCRIPTION
Currently, when working with threads, it's a bit tricky to use parameters from outside the thread. I thought it would be really cool if we could do that, so I made a small change to the function typedef to allow for this.

Now, with my proposed modification, you'll be able to use parameters outside of the thread. This is the code for a simple use case:
```c++
thread slowSetServoAsync(int step, int times) {
  thread myThread = thread_create([&step, &times] {
    for (int i = 0; i < times; i++) {
      set_servo_position(0, step * i);
      msleep(250);
    }
  });
  thread_start(myThread);
  return thread;
}
```