### PR TITLE
0425 wfl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ option(package_debian "Build a Debian package" OFF)
 
 set(KIPR_VERSION_MAJOR 1)
 set(KIPR_VERSION_MINOR 2)
-set(KIPR_VERSION_PATCH 0)
+set(KIPR_VERSION_PATCH 1)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/module/botball/src/botball_c.cpp
+++ b/module/botball/src/botball_c.cpp
@@ -84,6 +84,7 @@ void shut_down_in(double s)
 void colorbar(int i, int range);
 void wait_for_light(int light_port)
 {
+	setvbuf(stdout, NULL, _IONBF, 0);
 	int OK = 0, onval, offval, reading, i = 0, range;
 	while (!OK)
 	{
@@ -164,6 +165,7 @@ void wait_for_light(int light_port)
 			display_clear();
 		}
 	}
+	setvbuf(stdout, NULL, _IOFBF, BUFSIZ);
 }
 void colorbar(int i, int range)
 {

--- a/module/console/src/console.cpp
+++ b/module/console/src/console.cpp
@@ -7,5 +7,4 @@ using namespace kipr::console;
 void Console::clear()
 {
   printf("\f");
-  fflush(stdout);
 }


### PR DESCRIPTION
Calling `fflush` repeatedly in a short time frame seems to causes issues with the C++ and python bindings for `wait_for_light`. Instead, call `setvbuf` to disable stdout buffering altogether, then re-enable normal buffering behavior when done. A `.deb` file is available on my fork's release page.