### PR TITLE
Changing motor register shift from 4 to 2

### DIFF
--- a/module/motor/src/motor_p.cpp
+++ b/module/motor/src/motor_p.cpp
@@ -108,7 +108,7 @@ int kipr::motor::get_motor_bemf(unsigned int port)
 int kipr::motor::get_motor_bemf_vel(unsigned int port)
 {
   if (port >= NUM_MOTORS) return 0;
-  int val = Platform::instance()->readRegister32b(REG_RW_MOT_0_SP_H + 4 * fix_port(port));
+  int val = Platform::instance()->readRegister32b(REG_RW_MOT_0_SP_H + 2 * fix_port(port));
   return val;
 }
 


### PR DESCRIPTION
Changed the kipr::motor::get_motor_bemf_vel function to shift 2 registers instead of 4