### PR TITLE
AI Camera Autodetect

### DIFF
--- a/module/camera/src/USBNETVideo.hpp
+++ b/module/camera/src/USBNETVideo.hpp
@@ -87,10 +87,12 @@ public:
   bool read(cv::OutputArray image) override;
   static char * m_object_list;
 
-
 private:
   bool m_udp_opened;
   UsbFrameProcessor *m_data_receiver;
 };
+
+char * ai_camera_command(char * command, int bufferlength);
+bool ai_camera_check();
 
 #endif /* USBNETVideo_hpp */

--- a/module/camera/src/camera.cpp
+++ b/module/camera/src/camera.cpp
@@ -201,9 +201,12 @@ bool Device::open(const int number, Resolution resolution, Model model)
   m_model = model;
   m_resolution = resolution;
 
-/*HACK FOR AI CAM TEST*/
-m_model = AI_CAMERA;
-printf("AI_CAMERA SET\n");
+  /*Check FOR AI CAMERA*/
+  if(ai_camera_check())
+  {
+    m_model = AI_CAMERA;
+    printf("AI_CAMERA SET\n");
+  }
 
   if (m_model == WHITE_2016)
   {


### PR DESCRIPTION
This update allows the camera code in libwallaby to autodetect the AI camera.  It does this by attempting to send a status request to the AI Camera command server. If there is any failure, it assumes that the AI camera is either not there or not ready.

This patch requires the patch in pull request #4 for ai-rpi-cam to be installed in the AI camera software.