### PR TITLE
Add centroid calculation to the channel object for the AI camera

### DIFF
--- a/module/camera/src/channel_p.cpp
+++ b/module/camera/src/channel_p.cpp
@@ -129,7 +129,8 @@ ObjectVector TensorChannelImpl::findObjects(const Config &config)
 
 	/*debug*/std::cout << "findObjects " << t_object->box.x << " " << t_object->box.y << " " << t_object->box.width << " " << t_object->box.height << " " << t_object->confidence << std::endl; fflush(NULL);
 		ret.push_back(Object(
-			Point2<unsigned>(0,0),
+			Point2<unsigned>((t_object->box.x + t_object->box.x + t_object->box.width)/2,
+						(t_object->box.y + t_object->box.y + t_object->box.height)/2),
 			Rect<unsigned>(t_object->box.x, t_object->box.y, t_object->box.width, t_object->box.height),
 			t_object->confidence,
 			t_object->name,


### PR DESCRIPTION
Note: This is not a true centroid because the AI camera only provides a bounding box for the object and its type.

A true centroid calculation would calculate the center of mass for the object.  The KIPR blob tracking does provide this for single color blobs using the opencv functions. However, the AI camera object is multi-colored and would requite a bit more complex coding to provide this calculation since this would require object detection.